### PR TITLE
Fix package name for box64.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ We use [@ryanfortner](https://github.com/ryanfortner)'s apt repository to instal
 ```sh 
 $ sudo wget https://ryanfortner.github.io/box64-debs/box64.list -O /etc/apt/sources.list.d/box64.list
 $ wget -qO- https://ryanfortner.github.io/box64-debs/KEY.gpg | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/box64-debs-archive-keyring.gpg
-$ sudo apt update && sudo apt install box64-generic-arm -y
+$ sudo apt update && sudo apt install box64 -y
 $ sudo systemctl restart systemd-binfmt
 ```
 


### PR DESCRIPTION
Fixes #12 

I noticed the original instruction suggested installing `box64-generic-arm`, but that fails now:

```
jgeerling@ampere-workstation:~$ sudo apt update && sudo apt install box64-generic-arm -y
Hit:2 https://itai-nelken.github.io/weekly-box86-debs/debian  InRelease                                            
Hit:1 https://box64.debian.ryanfortner.dev/debian ./ InRelease                                                     
Hit:3 http://ports.ubuntu.com/ubuntu-ports jammy InRelease                                   
Hit:4 http://ports.ubuntu.com/ubuntu-ports jammy-updates InRelease                
Hit:5 http://ports.ubuntu.com/ubuntu-ports jammy-backports InRelease              
Hit:6 http://ports.ubuntu.com/ubuntu-ports jammy-security InRelease              
Hit:7 https://ppa.launchpadcontent.net/obsproject/obs-studio/ubuntu jammy InRelease
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
4 packages can be upgraded. Run 'apt list --upgradable' to see them.
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
E: Unable to locate package box64-generic-arm
```

It looks like the package name for generic arm64 is now just `box64`.