### PR TITLE
Fix command to install box86 keyring.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ We use [@Itai-Nelken](https://github.com/Itai-Nelken)'s apt repository to instal
 
 ```sh
 sudo wget https://itai-nelken.github.io/weekly-box86-debs/debian/box86.list -O /etc/apt/sources.list.d/box86.list
-wget -qO- https://itai-nelken.github.io/weekly-box86-debs/debian/KEY.gpg | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/box86-debs-archive-keyring.gpg
+wget -qO- https://itai-nelken.github.io/weekly-box86-debs/debian/KEY.gpg | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/weekly_box86_debs_keyring.gpg
 sudo dpkg --add-architecture armhf
 sudo apt update
 sudo apt install box86:armhf -y

--- a/STEAM on AADP.txt
+++ b/STEAM on AADP.txt
@@ -84,7 +84,7 @@ sudo dpkg --add-architecture armhf
 Use @Itai-Nelken's apt repository to install precompiled box86 debs, updated weekly.
 
 sudo wget https://itai-nelken.github.io/weekly-box86-debs/debian/box86.list -O /etc/apt/sources.list.d/box86.list
-wget -qO- https://itai-nelken.github.io/weekly-box86-debs/debian/KEY.gpg | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/box86-debs-archive-keyring.gpg
+wget -qO- https://itai-nelken.github.io/weekly-box86-debs/debian/KEY.gpg | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/weekly_box86_debs_keyring.gpg
 sudo apt update && sudo apt install box86:armhf -y
 
 


### PR DESCRIPTION
Without this fix, you wind up getting:

```
W: GPG error: https://itai-nelken.github.io/weekly-box86-debs/debian  InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY EB3CE9A337ECDFA4
E: The repository 'https://itai-nelken.github.io/weekly-box86-debs/debian  InRelease' is not signed.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
```

See the official box86 setup instructions: https://itai-nelken.github.io/weekly-box86-debs/